### PR TITLE
feat: add click to move

### DIFF
--- a/src/textual_chess/board.py
+++ b/src/textual_chess/board.py
@@ -12,7 +12,7 @@ from textual_chess.piece import Piece
 
 class EmptySquare(Widget):
     DEFAULT_CSS = """
-    Unoccupied {
+    EmptySquare {
         width: 8;
         height: 4;
     }
@@ -46,7 +46,6 @@ class ChessBoard(Widget):
 
     ChessBoard .selected-piece {
         background: #577c57;
-
     }
 
     ChessBoard .check {
@@ -57,7 +56,7 @@ class ChessBoard(Widget):
     orientation: var[chess.Color] = var(chess.WHITE, init=False)
     selected_piece: var[Piece | None] = var[Piece | None](None)
     selected_piece_legal_moves: list[str] | None = None
-    hovered_legal_move_square: var[Piece | EmptySquare | None] = var[
+    hovered_move_destination: var[Piece | EmptySquare | None] = var[
         Piece | EmptySquare | None
     ](None)
 
@@ -110,7 +109,7 @@ class ChessBoard(Widget):
         self.remove_children()
         orientation = self.orientation
         self.selected_piece = None
-        self.hovered_legal_move_square = None
+        self.hovered_move_destination = None
         self.selected_piece_legal_moves = None
         is_check = self.board.is_check()
         for rank_idx in range(7, -1, -1) if orientation else range(8):
@@ -166,18 +165,17 @@ class ChessBoard(Widget):
                     to_square=chess.parse_square(clicked_square_name),
                 )
                 self.make_move(move)
-                return
-
-        if not isinstance(clicked, Piece):
-            self.selected_piece = None
-            return
-        if (
-            clicked.chess_piece.color == self.board.turn
-            and clicked != self.selected_piece
-        ):
-            self.selected_piece = clicked
         else:
-            self.selected_piece = None
+            if not isinstance(clicked, Piece):
+                self.selected_piece = None
+                return
+            if (
+                clicked.chess_piece.color == self.board.turn
+                and clicked != self.selected_piece
+            ):
+                self.selected_piece = clicked
+            else:
+                self.selected_piece = None
 
     def get_square_name(self, square: Piece | EmptySquare) -> str:
         square_name: str = ""
@@ -215,11 +213,11 @@ class ChessBoard(Widget):
         assert isinstance(hovered, (Piece, EmptySquare))
         square_name = self.get_square_name(hovered)
         if square_name in self.selected_piece_legal_moves:
-            self.hovered_legal_move_square = hovered
+            self.hovered_move_destination = hovered
         else:
-            self.hovered_legal_move_square = None
+            self.hovered_move_destination = None
 
-    def watch_hovered_legal_move_square(
+    def watch_hovered_move_destination(
         self,
         old_hovered: Piece | EmptySquare | None,
         new_hovered: Piece | EmptySquare | None,

--- a/src/textual_chess/board.py
+++ b/src/textual_chess/board.py
@@ -39,9 +39,14 @@ class ChessBoard(Widget):
     ChessBoard .light-square {
         background: #f0d9b5;
     }
+
+    ChessBoard .selected-piece {
+        background: green;
+    }
     """
 
     orientation: var[chess.Color] = var(chess.WHITE, init=False)
+    selected_piece: var[Piece | None] = var[Piece | None](None)
 
     class MovePlayed(Message):
         def __init__(
@@ -127,6 +132,32 @@ class ChessBoard(Widget):
         outcome = self.board.outcome()
         if outcome is not None:
             self.post_message(self.GameOver(self, outcome))
+
+    def on_click(self, event: events.Click) -> None:
+        clicked, _ = self.screen.get_widget_at(
+            event.screen_x,
+            event.screen_y,
+        )
+        if not isinstance(clicked, Piece):
+            self.selected_piece = None
+            return
+        if (
+            clicked.chess_piece.color == self.board.turn
+            and clicked != self.selected_piece
+        ):
+            self.selected_piece = clicked
+        else:
+            self.selected_piece = None
+
+    def watch_selected_piece(
+        self,
+        old_selected: Piece | None,
+        new_selected: Piece | None,
+    ) -> None:
+        if old_selected is not None:
+            old_selected.set_class(False, "selected-piece")
+        if new_selected is not None:
+            new_selected.set_class(True, "selected-piece")
 
     def flip(self) -> None:
         self.orientation = not self.orientation

--- a/src/textual_chess/board.py
+++ b/src/textual_chess/board.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import chess
 from rich.console import RenderableType
+from textual import events
 from textual.message import Message
 from textual.reactive import var
 from textual.widget import Widget
@@ -91,17 +92,20 @@ class ChessBoard(Widget):
         self.remove_children()
         orientation = self.orientation
         is_check = self.board.is_check()
-        for rank_index in range(7, -1, -1) if orientation else range(8):
-            for file_index in range(8) if orientation else range(7, -1, -1):
-                square = chess.square(file_index, rank_index)
-                square_color = "light" if (rank_index + file_index) % 2 else "dark"
+        for rank_idx in range(7, -1, -1) if orientation else range(8):
+            for file_idx in range(8) if orientation else range(7, -1, -1):
+                square = chess.square(file_idx, rank_idx)
+                square_name = chess.square_name(square)
+                square_color = "light" if (rank_idx + file_idx) % 2 else "dark"
                 chess_piece = self.board.piece_at(square)
                 if chess_piece is None:
                     empty_square = EmptySquare()
+                    empty_square.add_class(f"square-{square_name}")
                     empty_square.add_class(f"{square_color}-square")
                     self.mount(empty_square)
                 else:
                     piece = Piece(chess_piece)
+                    piece.add_class(f"square-{square_name}")
                     piece.add_class(f"{square_color}-square")
                     if (
                         is_check

--- a/src/textual_chess/board.py
+++ b/src/textual_chess/board.py
@@ -40,12 +40,17 @@ class ChessBoard(Widget):
         background: #f0d9b5;
     }
 
-    ChessBoard .hovered-legal-move-square {
-        background: yellow;
+    ChessBoard .move-destination {
+        background: #87af87;
     }
 
     ChessBoard .selected-piece {
-        background: green;
+        background: #577c57;
+
+    }
+
+    ChessBoard .check {
+        background: #e70000;
     }
     """
 
@@ -128,7 +133,7 @@ class ChessBoard(Widget):
                         and chess_piece.piece_type == chess.KING
                         and chess_piece.color == self.board.turn
                     ):
-                        piece.styles.background = "red"
+                        piece.set_class(True, "check")
                     self.mount(piece)
 
     def make_move(self, move: chess.Move) -> None:
@@ -220,9 +225,9 @@ class ChessBoard(Widget):
         new_hovered: Piece | EmptySquare | None,
     ) -> None:
         if old_hovered is not None:
-            old_hovered.set_class(False, "hovered-legal-move-square")
+            old_hovered.set_class(False, "move-destination")
         if new_hovered is not None:
-            new_hovered.set_class(True, "hovered-legal-move-square")
+            new_hovered.set_class(True, "move-destination")
 
     def flip(self) -> None:
         self.orientation = not self.orientation

--- a/src/textual_chess/board.py
+++ b/src/textual_chess/board.py
@@ -144,11 +144,32 @@ class ChessBoard(Widget):
         if outcome is not None:
             self.post_message(self.GameOver(self, outcome))
 
+    def make_move_from_uci(self, uci: str) -> None:
+        move = self.board.parse_uci(uci)
+        final_san = self.board.san(move)
+        self.board.push(move)
+        self.update()
+        self.post_message(self.MovePlayed(self, move, final_san))
+
+        outcome = self.board.outcome()
+        if outcome is not None:
+            self.post_message(self.GameOver(self, outcome))
+
     def on_click(self, event: events.Click) -> None:
         clicked, _ = self.screen.get_widget_at(
             event.screen_x,
             event.screen_y,
         )
+        assert isinstance(clicked, (Piece, EmptySquare))
+        if self.selected_piece is not None:
+            piece_square_name = self.get_square_name(self.selected_piece)
+            clicked_square_name = self.get_square_name(clicked)
+            assert self.selected_piece_legal_moves is not None
+            if clicked_square_name in self.selected_piece_legal_moves:
+                move = f"{piece_square_name}{clicked_square_name}"
+                self.make_move_from_uci(move)
+                return
+
         if not isinstance(clicked, Piece):
             self.selected_piece = None
             return


### PR DESCRIPTION
Currently drag-and-drop moving of pieces isn't possible due to "Opacity/transparency issues with overlapped widgets" in Textual (as of v0.57.1).

This will at least provide some mouse interactivity, where you can move a piece by selecting it with the mouse and then clicking the square to move to. This also highlights legal moves for the selected piece when a square is hovered.


